### PR TITLE
action.yml: default GITHUB_TOKEN

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,8 @@ inputs:
     default: 'gh-pages'
   GITHUB_TOKEN:
     description: 'Token for the repo. Can be passed in using $\{{ secrets.GITHUB_TOKEN }}'
-    required: true
+    required: false
+    default: ${{ github.token }}
   CNAME:
     description: 'Your gh pages CNAME if any'
     required: false


### PR DESCRIPTION
action.yml can specify it wants the default `secrets.GITHUB_TOKEN` from [the context](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context), so customers don't have to provide it.

This is a common pattern in official actions:
* https://github.com/actions/checkout/blob/25a956c84d5dd820d28caab9f86b8d183aeeff3d/action.yml#L24
* https://github.com/actions/stale/blob/d3bfc506854e1df749b4398adcd2834777b4cbf8/action.yml#L8